### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,4 +1,6 @@
 name: Node.js CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/crispthinking/athena-nodejs-client/security/code-scanning/1](https://github.com/crispthinking/athena-nodejs-client/security/code-scanning/1)

To fix this problem, explicitly set the `permissions` key in the workflow to restrict the scope of the `GITHUB_TOKEN` to only those privileges actually needed for the tasks in the workflow. Since the shown steps only interact with the repository contents non-destructively, the minimal required permission is read access to contents. The best practice is to add `permissions: contents: read` near the top of the file (either at the root, applying to all jobs, or within the specific `build` job if finer granularity is needed). For clarity and future scalability, it's preferred to add it at the root level (just after the `name:`). No further imports, methods, or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
